### PR TITLE
Ignore phpdoc and tree-sitter-phpdoc in treesitter

### DIFF
--- a/nvim/lua/user/treesitter.lua
+++ b/nvim/lua/user/treesitter.lua
@@ -7,7 +7,7 @@ end
 configs.setup {
   ensure_installed = 'all', -- one of 'all', 'maintained' (parsers with maintainers), or a list of languages
   sync_install = false, -- install languages synchronously (only applied to `ensure_installed`)
-  ignore_install = { '' }, -- List of parsers to ignore installing
+  ignore_install = { "phpdoc", "tree-sitter-phpdoc" }, -- List of parsers to ignore installing. M1 Macs currently have an issue with phpdoc
   autopairs = {
     enable = false,
   },


### PR DESCRIPTION
There is currently and error with phpdoc and tree-sitter-phpdoc in treesitter on M1 Macs. This is a work around for now.