### PR TITLE
Add end of line marker

### DIFF
--- a/nvim/lua/user/options.lua
+++ b/nvim/lua/user/options.lua
@@ -32,6 +32,7 @@ set.smartcase = true
 
 -- show hidden characters
 set.list = true
+set.listchars = {eol = "↲"}
 set.listchars:append({extends = '»', precedes = '«', trail = '•'})
 
 vim.g.vscode_style = 'dark'


### PR DESCRIPTION
Adds a ↲ as an end of line marker. Seeing if I like it, may remove.