### PR TITLE
Skip no-commit-to-branch in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,3 +13,5 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: j178/prek-action@v2
+        env:
+          SKIP: no-commit-to-branch


### PR DESCRIPTION
It fails when testing runs on a merge to main